### PR TITLE
Fix Always Redirect

### DIFF
--- a/app/code/community/Devopensource/Redsys/controllers/IndexController.php
+++ b/app/code/community/Devopensource/Redsys/controllers/IndexController.php
@@ -11,7 +11,7 @@ class Devopensource_Redsys_IndexController extends Mage_Core_Controller_Front_Ac
         $orderId = Mage::getSingleton('checkout/session')->getLastRealOrderId();
         $_order = Mage::getModel('sales/order')->loadByIncrementId($orderId);
 
-        if($_order->getState() != 'new' || $_order->getStatus() != 'pending' ) {
+        if($_order->getState() != 'new' && $_order->getStatus() != 'pending' ) {
             $response = Mage::app()->getResponse();
             $response->setRedirect(Mage::getBaseUrl());
             $response->sendResponse();


### PR DESCRIPTION
$_order->getState() != 'new' || $_order->getStatus() != 'pending' => is always true, so we are always redirected on the home page.

if $_order->getState() == 'new' then  $_order->getStatus() != 'pending' is True and $_order->getState() != 'new' || $_order->getStatus() != 'pending' will be true too.

if $_order->getState() == 'pending' then  $_order->getStatus() != 'new' is True and $_order->getState() != 'new' || $_order->getStatus() != 'pending' will be true too.

Fixed by replace || operator by && operator.