### PR TITLE
Fixed canceled orders with null state - issue #57

### DIFF
--- a/app/code/community/Devopensource/Redsys/Helper/Data.php
+++ b/app/code/community/Devopensource/Redsys/Helper/Data.php
@@ -183,7 +183,7 @@ class Devopensource_Redsys_Helper_Data extends Mage_Core_Helper_Abstract {
         }
 
         // Notificacion privada
-        $this->setCustomState($_order,null, $status, $comment, false, false);
+        $this->setCustomState($_order, $state, $status, $comment, false, false);
         Mage::dispatchEvent('order_cancel_after', array('order' => $_order));
         $_order->save();
 


### PR DESCRIPTION
Con este cambio se corrigen 2 problemas:
- El pedido queda correctamente cancelado y con un `state` definido.
Anteriormente quedaba con estado `NULL` y no entraba en el `if` de la función `setCustomState`.

- El stock de los productos del pedido se restablecen correctamente.